### PR TITLE
Changed "rclone serve http" to "rclone serve webdav"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,4 @@ rclone version
 rclone config create 'CLOUDNAME' 'mega' 'user' $UserName 'pass' $PassWord
 rclone version
 rclone copy /donate-developeranaz.txt CLOUDNAME:
-rclone serve http CLOUDNAME: --addr :$PORT --buffer-size 256M --dir-cache-time 12h --vfs-read-chunk-size 256M --vfs-read-chunk-size-limit 2G --vfs-cache-mode writes
-
-
+rclone serve webdav CLOUDNAME: --addr :$PORT --buffer-size 256M --dir-cache-time 12h --vfs-read-chunk-size 256M --vfs-read-chunk-size-limit 2G --vfs-cache-mode writes


### PR DESCRIPTION
This allows it to serve both http and webdav. Webdav can be used with Air Explorer or any other webdav client to download complete folders in one go. Doesn't require any other scripts or extensions.